### PR TITLE
Add !choose

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import reddit from './plugins/reddit';
 import news from './plugins/news';
 import logger from './logger';
 import countdown from './plugins/countdown';
+import choose from './plugins/choose';
 
 const log = logger('bot:main');
 
@@ -17,6 +18,7 @@ async function init() {
 		reddit(client),
 		news(client),
 		countdown(client),
+		choose(client),
 	]);
 
 	const signals = {

--- a/src/plugins/choose.js
+++ b/src/plugins/choose.js
@@ -1,0 +1,23 @@
+import { RichEmbed } from 'discord.js';
+import logger from '../logger';
+
+const log = logger('plugins:choose');
+const chooseVerbs = ['chose', 'prefers', 'is thinking', 'is pondering',
+	'thinks of your best and picked', 'suggests', 'likes all of the options, but chose'];
+
+export default async function choose(discord) {
+	log.info('starting choose plugin');
+	discord.on('message', (msg) => {
+		if (msg.content.startsWith('!choose ')) {
+			const channel = msg.channel;
+			const choices = msg.content.substring(8).split(';');
+			if (choices.length > 1) {
+				const message = new RichEmbed();
+				message.description = `
+				:thinking: MoeBot ${chooseVerbs[Math.floor(Math.random() * chooseVerbs.length)]}...\n
+				${choices[Math.floor(Math.random() * choices.length)]}!`;
+				channel.send(message);
+			}
+		}
+	});
+}


### PR DESCRIPTION
Can replace Nadeko's .choose. Due to .choose being reserved for Nadeko, uses !choose instead. Since there's no way to completely disable commands from Nadeko, I would suggest we use ! prefix for Moebot commands.