### PR TITLE
Fix bolded link formatting on mobile

### DIFF
--- a/src/plugins/animeinfo.js
+++ b/src/plugins/animeinfo.js
@@ -26,7 +26,7 @@ function getTitle(anime) {
 }
 
 function getAnilistLink(anime, title) {
-	return `[**${title}**](https://anilist.co/anime/${anime.id})`;
+	return `**[${title}](https://anilist.co/anime/${anime.id})**`;
 }
 
 function secondsToDhms(s) {


### PR DESCRIPTION
Fixes bolded link formatting on mobile. Uses alternative placement for the ** characters which works also on mobile.