### PR TITLE
Sort anime by search match

### DIFF
--- a/src/plugins/animeinfo.js
+++ b/src/plugins/animeinfo.js
@@ -252,7 +252,7 @@ async function findAnime(searchTerm) {
 
 	const variables = {
 		search: searchTerm,
-		sort: ['STATUS', 'POPULARITY_DESC'],
+		sort: ['SEARCH_MATCH', 'STATUS', 'POPULARITY_DESC'],
 		type: 'ANIME',
 		isAdult: false,
 		status_in: ['RELEASING', 'NOT_YET_RELEASED'],


### PR DESCRIPTION
Anilist search seems to be returning an excessive amount of results when querying by a search term, which sometimes causes the desired anime to be buried in the amount of results. Sorting the results by search_match should show the most relevant results first.