### PR TITLE
Filter !when results to those matching the query

### DIFF
--- a/src/plugins/animeinfo.js
+++ b/src/plugins/animeinfo.js
@@ -92,7 +92,7 @@ function getMessage(data, description, maxResults) {
 	const message = new RichEmbed();
 	try {
 		message.description = description;
-		const totalAnime = data.data.Page.pageInfo.total;
+		const totalAnime = data.data.Page.media.length;
 		if (totalAnime > maxResults) {
 			message.description += `Found ${totalAnime} airing or upcoming anime. Showing the first ${maxResults}:\n`;
 		}
@@ -246,6 +246,7 @@ async function findAnime(searchTerm) {
 				coverImage{
 					large
 				}
+				synonyms
 			}
 		}
 	}`;
@@ -267,6 +268,11 @@ export default async function when(discord) {
 		if (msg.content.startsWith('!when ')) {
 			const query = msg.content.substr(6);
 			const data = await findAnime(query);
+			const q = query.toLowerCase();
+			data.data.Page.media = data.data.Page.media.filter(media => media.synonyms.some(s => s.toLowerCase().includes(q)
+				|| (media.title.romaji && media.title.romaji.toLowerCase().includes(q))
+				|| (media.title.native && media.title.native.toLowerCase().includes(q))
+				|| (media.title.english && media.title.english.toLowerCase().includes(q))));
 			const message = getSearchResultMessage(data);
 			msg.channel.send(message);
 		} else if (msg.content.startsWith('!today')) {


### PR DESCRIPTION
Since Anilist API returns also results that don't match the given query, adds manual filtering to the results returned from the API.

Before:
![image](https://user-images.githubusercontent.com/19351066/54882362-e0186480-4e61-11e9-8ef5-6e6579bdc4ae.png)

After:
![image](https://user-images.githubusercontent.com/19351066/54882363-eb6b9000-4e61-11e9-83b4-27dacfa5a2cd.png)
