### PR TITLE
Change !lcr to return available commands as a formatted table

### DIFF
--- a/src/plugins/emotes/index.js
+++ b/src/plugins/emotes/index.js
@@ -60,10 +60,11 @@ export default async function emotes(discord) {
 				}
 				return undefined;
 			}
-
-			return new RichEmbed({
-				description: [...new Set(emotesList.map(emote => emote.trigger))].map(x => `!${x}`).join('\n'),
-			});
+			const maxLength = Math.max(...emotesList.map(e => e.trigger.length)) + 1;
+			return `\`\`\`Usage: !command, e.g. !hug.\n${[...new Set(emotesList.map(emote => emote.trigger))]
+				.map(x => `${x}`.padEnd(maxLength, '\xa0'))
+				.sort((a, b) => a.localeCompare(b))
+				.join(' ')}\`\`\``;
 		}
 
 		return new RichEmbed({


### PR DESCRIPTION
Modifies !lcr to return available commands as a formatted code block instead of one command per line:

![image](https://user-images.githubusercontent.com/34946396/71321913-5caba280-24c9-11ea-8de9-ff2f0e978707.png)

Should also work on mobile.