### PR TITLE
Add menhera plugin

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -213,9 +213,6 @@
 	"window": [
 		"https://i.imgur.com/iTao6Ld.png"
 	],
-	"bang2": [
-		"https://i.imgur.com/NkeWZk7.png"
-	],
 	"peek": [
 		"https://i.imgur.com/Eml92R5.png",
 		"https://i.imgur.com/fvcy1xJ.png",
@@ -349,7 +346,7 @@
 	"ganbare": [
 		"https://i.imgur.com/1dd5hWt.png"
 	],
-	"ok2": [
+	"ok": [
 		"https://i.imgur.com/WmsBz9I.png",
 		"https://i.imgur.com/Y4ZnaT7.png"
 	],
@@ -445,7 +442,8 @@
 		"https://i.imgur.com/zuko1ZL.png"
 	],
 	"bang": [
-		"https://i.imgur.com/6wxdn9p.png"
+		"https://i.imgur.com/6wxdn9p.png",
+		"https://i.imgur.com/NkeWZk7.png"
 	],
 	"plop": [
 		"https://i.imgur.com/uF4MEWE.png"

--- a/config/default.json5
+++ b/config/default.json5
@@ -199,4 +199,361 @@
       },
     },
   },
+  "menhera": {
+	"embarrassed": [
+		"https://i.imgur.com/FkkQ1kU.png",
+		"https://i.imgur.com/yfSXaid.png"
+	],
+	"shy": [
+		"https://i.imgur.com/fXRT6qN.png"
+	],
+	"stir": [
+		"https://i.imgur.com/Ar1pZHc.png"
+	],
+	"window": [
+		"https://i.imgur.com/iTao6Ld.png"
+	],
+	"bang2": [
+		"https://i.imgur.com/NkeWZk7.png"
+	],
+	"peek": [
+		"https://i.imgur.com/Eml92R5.png",
+		"https://i.imgur.com/fvcy1xJ.png",
+		"https://i.imgur.com/hv83joy.png"
+	],
+	"overwhelmed": [
+		"https://i.imgur.com/i5RnMQU.png"
+	],
+	"morning": [
+		"https://i.imgur.com/TXPtQd3.png",
+		"https://i.imgur.com/aZcUdML.png"
+	],
+	"night": [
+		"https://i.imgur.com/Rp02Ujc.png",
+		"https://i.imgur.com/bnZre9C.png"
+	],
+	"bequiet": [
+		"https://i.imgur.com/Y8iZGOE.png"
+	],
+	"aloha": [
+		"https://i.imgur.com/61O8AF7.png"
+	],
+	"burnt": [
+		"https://i.imgur.com/8X4s8Ew.png"
+	],
+	"fan": [
+		"https://i.imgur.com/30iEXWd.png"
+	],
+	"fever": [
+		"https://i.imgur.com/0Aj9yQZ.png"
+	],
+	"goodjob": [
+		"https://i.imgur.com/pcNbGbm.png"
+	],
+	"havesomeair": [
+		"https://i.imgur.com/MzDUjtr.png"
+	],
+	"myeyes": [
+		"https://i.imgur.com/lbl357x.png"
+	],
+	"money": [
+		"https://i.imgur.com/kZn4mTE.png",
+		"https://i.imgur.com/BvFkWtn.png"
+	],
+	"shocked": [
+		"https://i.imgur.com/IxlJfZ9.png",
+		"https://i.imgur.com/D0pINpF.png"
+	],
+	"roll": [
+		"https://i.imgur.com/SP8SaKR.png"
+	],
+	"cheers": [
+		"https://i.imgur.com/U3jX6xA.png"
+	],
+	"slurp": [
+		"https://i.imgur.com/Mi6jteX.png"
+	],
+	"nom": [
+		"https://i.imgur.com/i0DoQCi.png",
+		"https://i.imgur.com/9sma6HG.png",
+		"https://i.imgur.com/frR1JuV.png",
+		"https://i.imgur.com/xB2NvV7.png",
+		"https://i.imgur.com/xB2NvV7.png"
+	],
+	"bringiton": [
+		"https://i.imgur.com/LD5gnX0.png"
+	],
+	"bored": [
+		"https://i.imgur.com/NXE38YZ.png",
+		"https://i.imgur.com/MQUkArC.png"
+	],
+	"thankyou": [
+		"https://i.imgur.com/fEW4zuY.png"
+	],
+	"great": [
+		"https://i.imgur.com/ZzvALoK.png"
+	],
+	"dingdong": [
+		"https://i.imgur.com/L7UJ8SB.png",
+		"https://i.imgur.com/nbmjWx9.png",
+		"https://i.imgur.com/ja00lfz.png",
+		"https://i.imgur.com/dDMtUqA.png",
+		"https://i.imgur.com/dDMtUqA.png"
+	],
+	"whisper": [
+		"https://i.imgur.com/QgBX24s.png",
+		"https://i.imgur.com/5nGZdfM.png"
+	],
+	"nono": [
+		"https://i.imgur.com/Jy90q2O.png"
+	],
+	"thefuck": [
+		"https://i.imgur.com/58SoEoP.png"
+	],
+	"doublethumbs": [
+		"https://i.imgur.com/BlJBrb8.png"
+	],
+	"study": [
+		"https://i.imgur.com/bClsabK.png",
+		"https://i.imgur.com/LihtMmq.png"
+	],
+	"yeah": [
+		"https://i.imgur.com/6UC7lKA.png"
+	],
+	"chillout": [
+		"https://i.imgur.com/RMT93V9.png"
+	],
+	"punch": [
+		"https://i.imgur.com/5W55k6n.png",
+		"https://i.imgur.com/oz4q6PE.png"
+	],
+	"happy": [
+		"https://i.imgur.com/ng0YX8B.png"
+	],
+	"wow": [
+		"https://i.imgur.com/jzIi0xa.png"
+	],
+	"hungry": [
+		"https://i.imgur.com/3vw6P88.png"
+	],
+	"pervert": [
+		"https://i.imgur.com/NVb1gXx.png",
+		"https://i.imgur.com/cbrXzrC.png"
+	],
+	"tehee": [
+		"https://i.imgur.com/oXNJc2Z.png"
+	],
+	"drumroll": [
+		"https://i.imgur.com/3T6aTZo.png"
+	],
+	"ganbare": [
+		"https://i.imgur.com/1dd5hWt.png"
+	],
+	"ok2": [
+		"https://i.imgur.com/WmsBz9I.png",
+		"https://i.imgur.com/Y4ZnaT7.png"
+	],
+	"zzz": [
+		"https://i.imgur.com/owKSKM3.png"
+	],
+	"fingerguns": [
+		"https://i.imgur.com/qhDJClX.png"
+	],
+	"good": [
+		"https://i.imgur.com/B39K0Ia.png"
+	],
+	"nervous": [
+		"https://i.imgur.com/MRRR2Nm.png"
+	],
+	"love": [
+		"https://i.imgur.com/PZtGEYh.png",
+		"https://i.imgur.com/MgqOaC0.png",
+		"https://i.imgur.com/9cNsNAL.png"
+	],
+	"tired": [
+		"https://i.imgur.com/SgRCyA2.png",
+		"https://i.imgur.com/XQXaqJL.png"
+	],
+	"knock": [
+		"https://i.imgur.com/4TpEaX5.png"
+	],
+	"really": [
+		"https://i.imgur.com/ce3CV10.png"
+	],
+	"sad": [
+		"https://i.imgur.com/dU17pXh.png"
+	],
+	"hey": [
+		"https://i.imgur.com/zRly4hV.png"
+	],
+	"annoyed": [
+		"https://i.imgur.com/HMZeyNP.png"
+	],
+	"wink": [
+		"https://i.imgur.com/p6x1IAL.png"
+	],
+	"fuee": [
+		"https://i.imgur.com/4UfvJ3T.png"
+	],
+	"sob": [
+		"https://i.imgur.com/1OrRVlB.png"
+	],
+	"pout": [
+		"https://i.imgur.com/w5o86Td.png",
+		"https://i.imgur.com/JRwIojz.png",
+		"https://i.imgur.com/8ibPzPq.png",
+		"https://i.imgur.com/1gfEcwb.png",
+		"https://i.imgur.com/T3hCr4y.png"
+	],
+	"impossible": [
+		"https://i.imgur.com/I5SS786.png"
+	],
+	"damn": [
+		"https://i.imgur.com/Gsw8Ipe.png"
+	],
+	"who": [
+		"https://i.imgur.com/YBugpZc.png"
+	],
+	"wave": [
+		"https://i.imgur.com/iCDbIp1.png"
+	],
+	"yessir": [
+		"https://i.imgur.com/Y0JnhDD.png"
+	],
+	"lazy": [
+		"https://i.imgur.com/5i2UpV0.png"
+	],
+	"pillowcry": [
+		"https://i.imgur.com/jcUJIb1.png"
+	],
+	"cold": [
+		"https://i.imgur.com/4kf6dNx.png"
+	],
+	"sleepy": [
+		"https://i.imgur.com/MXA98xN.png"
+	],
+	"sleeping": [
+		"https://i.imgur.com/EUWGgEV.png"
+	],
+	"bathtime": [
+		"https://i.imgur.com/cBOF97I.png"
+	],
+	"salute": [
+		"https://i.imgur.com/ie6ILzV.png"
+	],
+	"music": [
+		"https://i.imgur.com/zuko1ZL.png"
+	],
+	"bang": [
+		"https://i.imgur.com/6wxdn9p.png"
+	],
+	"plop": [
+		"https://i.imgur.com/uF4MEWE.png"
+	],
+	"thumbsup": [
+		"https://i.imgur.com/qWUBm1v.png"
+	],
+	"food": [
+		"https://i.imgur.com/DzFmskA.png"
+	],
+	"squat": [
+		"https://i.imgur.com/G6SXQdD.png"
+	],
+	"eww": [
+		"https://i.imgur.com/uoUqzmD.png"
+	],
+	"noway": [
+		"https://i.imgur.com/YjplvTz.png"
+	],
+	"hello": [
+		"https://i.imgur.com/ZRHnqin.png"
+	],
+	"hurray": [
+		"https://i.imgur.com/8gphVeU.png"
+	],
+	"o": [
+		"https://i.imgur.com/yeYZV6s.png",
+		"https://i.imgur.com/GpLMp8J.png"
+	],
+	"x": [
+		"https://i.imgur.com/JT3kFMP.png",
+		"https://i.imgur.com/UEMaHzj.png"
+	],
+	"understand": [
+		"https://i.imgur.com/CPC9430.png"
+	],
+	"police": [
+		"https://i.imgur.com/lAozemE.png"
+	],
+	"think": [
+		"https://i.imgur.com/5zSgse4.png",
+		"https://i.imgur.com/GmGUF9F.png"
+	],
+	"cat": [
+		"https://i.imgur.com/F5dCrjc.png"
+	],
+	"swing": [
+		"https://i.imgur.com/WWAISiu.png",
+		"https://i.imgur.com/KC3MqgM.png"
+	],
+	"pwn": [
+		"https://i.imgur.com/RlYhYva.png"
+	],
+	"no": [
+		"https://i.imgur.com/sUOEefr.png"
+	],
+	"full": [
+		"https://i.imgur.com/17jQaAX.png"
+	],
+	"yes": [
+		"https://i.imgur.com/6s3FD7F.png"
+	],
+	"forgiveme": [
+		"https://i.imgur.com/QPBZ64F.png"
+	],
+	"iforgive": [
+		"https://i.imgur.com/4iCcNX4.png"
+	],
+	"smug": [
+		"https://i.imgur.com/whzkhW9.png"
+	],
+	"hot": [
+		"https://i.imgur.com/UNFVkL2.png"
+	],
+	"crying": [
+		"https://i.imgur.com/j3PQ8b9.png"
+	],
+	"nooo": [
+		"https://i.imgur.com/iq5uOLv.png"
+	],
+	"huh": [
+		"https://i.imgur.com/DPYS3Y1.png",
+		"https://i.imgur.com/v05LdQS.png",
+		"https://i.imgur.com/Ga5dzCs.png",
+		"https://i.imgur.com/BPgAMXX.png"
+	],
+	"blush": [
+		"https://i.imgur.com/OoZNBrs.png",
+		"https://i.imgur.com/7wldHBE.png"
+	],
+	"whatsup": [
+		"https://i.imgur.com/3eqdsT6.png"
+	],
+	"badsmell": [
+		"https://i.imgur.com/VvSKBYx.png"
+	],
+	"notlike": [
+		"https://i.imgur.com/a5Sa2b2.png"
+	],
+	"dogeza": [
+		"https://i.imgur.com/47OqJHo.png"
+	],
+	"awoken": [
+		"https://i.imgur.com/eBuNOan.png"
+	],
+	"devastated": [
+		"https://i.imgur.com/kuYPlA0.png"
+	]
+}
+
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import eventlog from './plugins/eventlog';
 import danbooru from './plugins/danbooru';
 import * as redditPoller from './plugins/reddit/poller';
 import reposts from './plugins/reddit/reposts';
+import menhera from './plugins/menhera';
 
 const log = logger('bot:main');
 
@@ -38,6 +39,7 @@ async function init() {
 			youtube(client),
 			eventlog(client),
 			danbooru(client),
+			menhera(client),
 		]);
 	} catch (e) {
 		log.error('Unexpected exception setting up plugins', e);

--- a/src/plugins/menhera.js
+++ b/src/plugins/menhera.js
@@ -4,36 +4,41 @@ import logger from '../logger';
 
 const emotes = config.get('menhera');
 const log = logger('plugins:menhera');
+const emoteCount = Object.keys(emotes).length;
 
 function processMenheraComment(msg) {
 	const split = msg.content.split(' ');
 	const message = new RichEmbed();
+
 	if (split.length !== 1) {
-		let list;
-		if (split[1] === 'random') {
-			list = emotes.get([...Object.keys(emotes)][Math.floor(Math.random() * Object.keys(emotes).length)]);
-		} else {
-			if (!emotes.hasOwnProperty(split[1])) {
-				message.description = `No reaction found: ${split[1]}. See !mh or !menhera for available emotes.`;
-				msg.channel.send(message);
-				return;
-			}
-			list = emotes.get(split[1]);
+		const emote = split[1];
+		if (emote === 'help') {
+			const keys = Object.keys(emotes);
+			keys.sort();
+			message.description = `Usage: !mh/!menhera *emote*. 
+			Testing in **#botspam** please!\nAvailable emotes:\n${keys.join(', ')}.`;
+			msg.channel.send(message);
+			return;
 		}
+		if (!Object.prototype.hasOwnProperty.call(emotes, emote)) {
+			message.description = `No emote found: ${emote}. See !mh help for available emotes.`;
+			msg.channel.send(message);
+			return;
+		}
+		const list = emotes.get(emote);
 		message.image = { url: list[Math.floor(Math.random() * list.length)] };
 		msg.channel.send(message);
 		return;
 	}
-	const keys = Object.keys(emotes);
-	keys.sort();
-	keys.push('random');
-	message.description = `Usage: !mh/!menhera *emote*. 
-	Testing in **#botspam** please!\nAvailable emotes:\n${keys.join(', ')}.`;
+	const randomEmote = Object.keys(emotes)[Math.floor(Math.random() * emoteCount)];
+	const list = emotes.get(randomEmote);
+	message.image = { url: list[Math.floor(Math.random() * list.length)] };
+	message.description = randomEmote;
 	msg.channel.send(message);
 }
 
 export default async function menhera(discord) {
-	log.info(`starting menhera plugin. ${Object.keys(emotes).length} emotes loaded.`);
+	log.info(`starting menhera plugin. ${emoteCount} emotes loaded.`);
 	discord.on('message', (msg) => {
 		if (msg.content.startsWith('!menhera') || msg.content.startsWith('!mh')) {
 			processMenheraComment(msg);

--- a/src/plugins/menhera.js
+++ b/src/plugins/menhera.js
@@ -1,0 +1,51 @@
+import { RichEmbed } from 'discord.js';
+import config from 'config';
+import logger from '../logger';
+
+const data = config.get('menhera');
+const log = logger('plugins:menhera');
+
+function objToStrMap(obj) {
+	const strMap = new Map();
+	Object.keys(obj).forEach((k) => {
+		strMap.set(k, obj[k]);
+	});
+	return strMap;
+}
+
+const emotes = objToStrMap(data);
+
+function processMenheraComment(msg) {
+	const split = msg.content.split(' ');
+	const message = new RichEmbed();
+	if (split.length !== 1) {
+		let list;
+		if (split[1] === 'random') {
+			list = emotes.get([...emotes.keys()][Math.floor(Math.random() * emotes.size)]);
+		} else {
+			list = emotes.get(split[1]);
+			if (!list) {
+				message.description = `No reaction found: ${split[1]}. See !mh or !menhera for available emotes.`;
+				msg.channel.send(message);
+				return;
+			}
+		}
+		message.image = { url: list[Math.floor(Math.random() * list.length)] };
+		msg.channel.send(message);
+	}
+	const keys = Array.from(emotes.keys());
+	keys.sort();
+	keys.push('random');
+	message.description = `Usage: !mh/!menhera *emote*. 
+	Testing in **#botspam** please!\nAvailable emotes:\n${keys.join(', ')}.`;
+	msg.channel.send(message);
+}
+
+export default async function menhera(discord) {
+	log.info(`starting menhera plugin. ${emotes.size} emotes loaded.`);
+	discord.on('message', (msg) => {
+		if (msg.content.startsWith('!menhera') || msg.content.startsWith('!mh')) {
+			processMenheraComment(msg);
+		}
+	});
+}

--- a/src/plugins/menhera.js
+++ b/src/plugins/menhera.js
@@ -2,18 +2,8 @@ import { RichEmbed } from 'discord.js';
 import config from 'config';
 import logger from '../logger';
 
-const data = config.get('menhera');
+const emotes = config.get('menhera');
 const log = logger('plugins:menhera');
-
-function objToStrMap(obj) {
-	const strMap = new Map();
-	Object.keys(obj).forEach((k) => {
-		strMap.set(k, obj[k]);
-	});
-	return strMap;
-}
-
-const emotes = objToStrMap(data);
 
 function processMenheraComment(msg) {
 	const split = msg.content.split(' ');
@@ -21,19 +11,20 @@ function processMenheraComment(msg) {
 	if (split.length !== 1) {
 		let list;
 		if (split[1] === 'random') {
-			list = emotes.get([...emotes.keys()][Math.floor(Math.random() * emotes.size)]);
+			list = emotes.get([...Object.keys(emotes)][Math.floor(Math.random() * Object.keys(emotes).length)]);
 		} else {
-			list = emotes.get(split[1]);
-			if (!list) {
+			if (!emotes.hasOwnProperty(split[1])) {
 				message.description = `No reaction found: ${split[1]}. See !mh or !menhera for available emotes.`;
 				msg.channel.send(message);
 				return;
 			}
+			list = emotes.get(split[1]);
 		}
 		message.image = { url: list[Math.floor(Math.random() * list.length)] };
 		msg.channel.send(message);
+		return;
 	}
-	const keys = Array.from(emotes.keys());
+	const keys = Object.keys(emotes);
 	keys.sort();
 	keys.push('random');
 	message.description = `Usage: !mh/!menhera *emote*. 
@@ -42,7 +33,7 @@ function processMenheraComment(msg) {
 }
 
 export default async function menhera(discord) {
-	log.info(`starting menhera plugin. ${emotes.size} emotes loaded.`);
+	log.info(`starting menhera plugin. ${Object.keys(emotes).length} emotes loaded.`);
 	discord.on('message', (msg) => {
 		if (msg.content.startsWith('!menhera') || msg.content.startsWith('!mh')) {
 			processMenheraComment(msg);


### PR DESCRIPTION
Adds Menhera plugin, which allows using emotes listed on https://stickersurge.com/pack/menhera with command !mh or !menhera *emote*. !mh / !menhera lists all available emotes. *random* emote is also available. Available emotes are configured in the config file.